### PR TITLE
fix(install-zsh): bugfix branch name info not displayed

### DIFF
--- a/other/install-zsh
+++ b/other/install-zsh
@@ -111,9 +111,9 @@ user_host="%F{blue}[%F{cyan}\$user_name%F{yellow} \$DISTRO_ICON %F{cyan}%m%F{blu
 dir_display="%F{blue}[%F{yellow}%~%F{blue}]%f"
 
 # Prompt layout (P10K-like)
-PROMPT="
+PROMPT='
 %B%F{green}╭─ \$user_host \$dir_display\${vcs_info_msg_0_}
-%B%F{green}╰─\${PROMPT_SYMBOL} %F{reset}"
+%B%F{green}╰─\${PROMPT_SYMBOL} %F{reset}'
 RPROMPT="\$exit_status"
 EOF
 

--- a/other/install-zsh
+++ b/other/install-zsh
@@ -70,11 +70,10 @@ cat << EOF > .zsh-themes/td.zsh-theme
 autoload -Uz colors && colors
 autoload -Uz vcs_info
 
-setopt PROMPT_SUBST
-
 # Enable Git branch display
 zstyle ':vcs_info:git:*' formats ' %F{magenta} %b%f'
 precmd() { vcs_info }
+setopt PROMPT_SUBST
 
 # Exit status indicator
 exit_status="%(?..%F{red}✘ %?%f)"


### PR DESCRIPTION
I found that the branch name is not displayed in a directory that came from a git repository, here is the fix that I propose.

Local test (before and after with arrange the order to fix):
![Screenshot_20250402_004043_TermuxX11](https://github.com/user-attachments/assets/ec973f1c-f106-4e8b-ba2d-e416652c3c58)
